### PR TITLE
Prevent webpack process from hanging

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ class PrimusWebpackPlugin {
         },
       };
 
+      primus.destroy();
       cb(null);
     });
 


### PR DESCRIPTION
After initialising Primus, it's never closed or destroyed, so it's still awaiting connections, etc. This fix resolves that, and destroys the Primus instance after it's been utilised, preventing errors with CI builds, etc.